### PR TITLE
Use flit, conda-souschef, and grayskull to make PyPI/Anaconda uploads straightforward.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 
 # Vim files
 *.sw*
+scratch/LICENSE
+scratch/meta.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "uncertainty_toolbox"
+authors = [
+    {name = "Willie Neiswanger", email = "willie.neiswanger@gmail.com"},
+    {name = "Youngseog Chung"},
+    {name = "Ian Char"},
+    {name = "Han Guo"},
+    ]
+readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"
+    ]
+dynamic = ["version", "description"]
+
+requires-python = ">=3.6"
+
+dependencies = [
+    "numpy>=1.19.0",
+    "scipy>=1.5.0",
+    "matplotlib>=3.2.2",
+    "scikit-learn>=0.23.1",
+    "shapely>=1.6.4.post2",
+    "tqdm>=4.54.0",
+    "pytest>=5.4.3",
+    "black>=19.10b0",
+]
+
+[project.urls]
+Home = "https://github.com/uncertainty-toolbox/uncertainty-toolbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent"
+    "Operating System :: OS Independent",
     ]
 dynamic = ["version", "description"]
 

--- a/run_grayskull.py
+++ b/run_grayskull.py
@@ -1,0 +1,23 @@
+"""Touch up the conda recipe from grayskull using conda-souschef."""
+import os
+from shutil import copyfile
+from os.path import join
+from pathlib import Path
+
+# from chardet import detect
+from souschef.recipe import Recipe
+
+import uncertainty_toolbox as module
+
+os.system(f"grayskull pypi {module.__name__}=={module.__version__}")
+
+fpath = join(module.__name__, "meta.yaml")
+Path("scratch").mkdir(exist_ok=True)
+fpath2 = join("scratch", "meta.yaml")
+my_recipe = Recipe(load_file=fpath)
+my_recipe["requirements"]["host"].append("flit")
+del my_recipe["test"]["imports"].yaml[0]  # delete "import tests" test
+my_recipe.save(fpath)
+my_recipe.save(fpath2)
+
+copyfile("LICENSE", join("scratch", "LICENSE"))

--- a/uncertainty_toolbox/__init__.py
+++ b/uncertainty_toolbox/__init__.py
@@ -1,4 +1,4 @@
-"""Code for the Uncertainty Toolbox"""
+"""A python toolbox for predictive uncertainty quantification, calibration, metrics, and visualization."""
 __version__ = "0.1.0"
 
 from .data import (

--- a/uncertainty_toolbox/__init__.py
+++ b/uncertainty_toolbox/__init__.py
@@ -1,6 +1,5 @@
-"""
-Code for the Uncertainty Toolbox
-"""
+"""Code for the Uncertainty Toolbox"""
+__version__ = "0.1.0"
 
 from .data import (
     synthetic_arange_random,

--- a/uncertainty_toolbox/meta.yaml
+++ b/uncertainty_toolbox/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "uncertainty_toolbox" %}
+{% set version = "0.1.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/uncertainty_toolbox-{{ version }}.tar.gz
+  sha256: e1a84ff0aba101d29535c80541de1d8a1827a12e48925b68c4bbb759d1be15f3
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - flit
+  run:
+    - black >=19.10b0
+    - matplotlib-base >=3.2.2
+    - numpy >=1.19.0
+    - pytest >=5.4.3
+    - python >=3.6
+    - scikit-learn >=0.23.1
+    - scipy >=1.5.0
+    - shapely >=1.6.4.post2
+    - tqdm >=4.54.0
+
+test:
+  imports:
+    - uncertainty_toolbox
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/uncertainty-toolbox/uncertainty-toolbox
+  summary: A python toolbox for predictive uncertainty quantification, calibration, metrics, and visualization.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - sgbaird


### PR DESCRIPTION
#59 #58 
Right now, I have a version of `uncertainty_toolbox` uploaded to PyPI and Anaconda.
```bash
pip install uncertainty_toolbox
```
```bash
conda install -c sgbaird uncertainty_toolbox
```

The basic instructions (after some one-time setup) are to install flit (e.g. `conda install flit`), update the version number in `uncertainty_toolbox/__init__.py` and run:
```bash
flit publish
```
to upload a new version to PyPI. I probably need to add other people's usernames to PyPI so I'm not the only one that can upload new versions.

For the Anaconda upload, install `conda-souschef` and `grayskull`, run a slightly customized script, and build it within the `scratch` folder.
```bash
conda install conda-souschef grayskull
python run_grayskull.py
cd scratch
conda build .
```
For this, you probably have to set a few things with conda first, such as automatic uploads when building, credentials, and configuring it to look in certain channels. These are all one-time setup instructions. I also have some [GitHub workflow code in mat_discover](https://github.com/sparks-baird/mat_discover/blob/main/.github/workflows/test-publish-release.yml) that can take care of the uploads (and testing) automatically when you make a new release. Just need to change a couple lines and add credentials to GitHub secrets.