### PR TITLE
fix docs/conf.py css file parameter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,16 +73,13 @@ html_theme_options = {
     'collapse_navigation': False,
 }
 
-html_context = {
-    'css_files': [
-	'_static/css/custom.css'
-    ],
-}
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = [
+    "css/custom.css",
+]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
Update `docs/conf.py` parameter linking to custom css file in order to build docs correctly.