### PR TITLE
Add support to PyTorch tensors and GPU acceleration

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,6 +4,7 @@ Tests for metrics.
 
 import pytest
 import numpy as np
+import torch
 
 from uncertainty_toolbox.metrics import (
     get_all_accuracy_metrics,
@@ -20,6 +21,14 @@ def get_test_set():
     y_pred = np.array([1, 2, 3])
     y_std = np.array([0.1, 0.5, 1])
     y_true = np.array([1.5, 3, 2])
+    return y_pred, y_std, y_true
+
+
+@pytest.fixture
+def get_test_set_torch():
+    y_pred = torch.tensor([1., 2., 3.])
+    y_std = torch.tensor([0.1, 0.5, 1])
+    y_true = torch.tensor([1.5, 3, 2])
     return y_pred, y_std, y_true
 
 
@@ -96,6 +105,93 @@ def test_get_all_scoring_rule_metrics_returns(get_test_set):
 def test_get_all_metrics_returns(get_test_set):
     """Test if correct metrics are returned by get_all_metrics function."""
     met_dict = get_all_metrics(*get_test_set)
+    met_keys = met_dict.keys()
+    assert len(met_keys) == 5
+
+    met_str_list = [
+        "accuracy",
+        "avg_calibration",
+        "adv_group_calibration",
+        "sharpness",
+        "scoring_rule",
+    ]
+    bool_list = [s in met_keys for s in met_str_list]
+    assert all(bool_list)
+
+
+def test_get_all_accuracy_metrics_returns_torch(get_test_set_torch):
+    """Test if correct accuracy metrics are returned."""
+    y_pred, y_std, y_true = get_test_set_torch
+    met_dict = get_all_accuracy_metrics(y_pred, y_true)
+    met_keys = met_dict.keys()
+    assert len(met_keys) == 6
+
+    met_str_list = ["mae", "rmse", "mdae", "marpd", "r2", "corr"]
+    bool_list = [s in met_keys for s in met_str_list]
+    assert all(bool_list)
+
+
+def test_get_all_average_calibration_returns_torch(get_test_set_torch):
+    """Test if correct average calibration metrics are returned."""
+    n_bins = 20
+    met_dict = get_all_average_calibration(*get_test_set_torch, n_bins)
+    met_keys = met_dict.keys()
+    assert len(met_keys) == 3
+
+    met_str_list = ["rms_cal", "ma_cal", "miscal_area"]
+    bool_list = [s in met_keys for s in met_str_list]
+    assert all(bool_list)
+
+
+def test_get_all_adversarial_group_calibration_returns_torch(get_test_set_torch):
+    """Test if correct adversarial group calibration metrics are returned."""
+    n_bins = 20
+    met_dict = get_all_adversarial_group_calibration(*get_test_set_torch, n_bins)
+    met_keys = met_dict.keys()
+    assert len(met_keys) == 2
+
+    met_str_list = ["ma_adv_group_cal", "rms_adv_group_cal"]
+    bool_list = [s in met_keys for s in met_str_list]
+    assert all(bool_list)
+
+    for met_str in met_str_list:
+        inner_dict = met_dict[met_str]
+        inner_keys = inner_dict.keys()
+        assert len(inner_keys) == 3
+        inner_str_list = [
+            "group_sizes",
+            "adv_group_cali_mean",
+            "adv_group_cali_stderr",
+        ]
+        bool_list = [s in inner_keys for s in inner_str_list]
+        assert all(bool_list)
+
+
+def test_get_all_sharpness_metrics_returns_torch(get_test_set_torch):
+    """Test if correct sharpness metrics are returned."""
+    y_pred, y_std, y_true = get_test_set_torch
+    met_dict = get_all_sharpness_metrics(y_std)
+    met_keys = met_dict.keys()
+    assert len(met_keys) == 1
+    assert "sharp" in met_keys
+
+
+def test_get_all_scoring_rule_metrics_returns_torch(get_test_set_torch):
+    """Test if correct scoring rule metrics are returned."""
+    resolution = 99
+    scaled = True
+    met_dict = get_all_scoring_rule_metrics(*get_test_set_torch, resolution, scaled)
+    met_keys = met_dict.keys()
+    assert len(met_keys) == 4
+
+    met_str_list = ["nll", "crps", "check", "interval"]
+    bool_list = [s in met_keys for s in met_str_list]
+    assert all(bool_list)
+
+
+def test_get_all_metrics_returns_torch(get_test_set_torch):
+    """Test if correct metrics are returned by get_all_metrics function."""
+    met_dict = get_all_metrics(*get_test_set_torch)
     met_keys = met_dict.keys()
     assert len(met_keys) == 5
 

--- a/tests/test_metrics_accuracy.py
+++ b/tests/test_metrics_accuracy.py
@@ -4,6 +4,7 @@ Tests for accuracy metrics.
 
 import pytest
 import numpy as np
+import torch
 
 from uncertainty_toolbox.metrics_accuracy import prediction_error_metrics
 
@@ -13,6 +14,14 @@ def get_test_set():
     y_pred = np.array([1, 2, 3])
     y_std = np.array([0.1, 0.5, 1])
     y_true = np.array([1.25, 2.2, 2.8])
+    return y_pred, y_std, y_true
+
+
+@pytest.fixture
+def get_test_set_torch():
+    y_pred = torch.tensor([1., 2., 3.])
+    y_std = torch.tensor([0.1, 0.5, 1])
+    y_true = torch.tensor([1.25, 2.2, 2.8])
     return y_pred, y_std, y_true
 
 
@@ -33,6 +42,17 @@ def test_prediction_error_metric_values(get_test_set):
     y_pred, y_std, y_true = get_test_set
     met_dict = prediction_error_metrics(y_pred, y_true)
     print(met_dict)
+    assert met_dict["mae"] > 0.21 and met_dict["mae"] < 0.22
+    assert met_dict["rmse"] > 0.21 and met_dict["rmse"] < 0.22
+    assert met_dict["mdae"] >= 0.20 and met_dict["mdae"] < 0.21
+    assert met_dict["marpd"] > 12 and met_dict["marpd"] < 13
+    assert met_dict["r2"] > 0.88 and met_dict["r2"] < 0.89
+    assert met_dict["corr"] > 0.99 and met_dict["corr"] < 1.0
+
+
+def test_prediction_error_metric_values_torch(get_test_set_torch):
+    y_pred, y_std, y_true = get_test_set_torch
+    met_dict = prediction_error_metrics(y_pred, y_true)
     assert met_dict["mae"] > 0.21 and met_dict["mae"] < 0.22
     assert met_dict["rmse"] > 0.21 and met_dict["rmse"] < 0.22
     assert met_dict["mdae"] >= 0.20 and met_dict["mdae"] < 0.21

--- a/tests/test_metrics_calibration.py
+++ b/tests/test_metrics_calibration.py
@@ -2,6 +2,7 @@
 Tests for calibration metrics.
 """
 import numpy as np
+import torch
 import pytest
 
 from uncertainty_toolbox.metrics_calibration import (
@@ -27,9 +28,20 @@ def supply_test_set():
     return y_pred, y_std, y_true
 
 
-def test_sharpness_on_test_set(supply_test_set):
+@pytest.fixture
+def supply_test_set_torch():
+    y_pred = torch.tensor([1., 2., 3.])
+    y_std = torch.tensor([0.1, 0.5, 1])
+    y_true = torch.tensor([1.5, 3, 2])
+    return y_pred, y_std, y_true
+
+
+def test_sharpness_on_test_set(supply_test_set, supply_test_set_torch):
     """Test sharpness on the test set for some dummy values."""
     _, test_std, _ = supply_test_set
+    assert np.abs(sharpness(test_std) - 0.648074069840786) < 1e-6
+    
+    _, test_std, _ = supply_test_set_torch
     assert np.abs(sharpness(test_std) - 0.648074069840786) < 1e-6
 
 
@@ -64,6 +76,49 @@ def test_root_mean_squared_calibration_error_on_test_set(supply_test_set):
     )
     test_rmsce_vectorized_quantile = root_mean_squared_calibration_error(
         *supply_test_set,
+        num_bins=100,
+        vectorized=True,
+        recal_model=None,
+        prop_type="quantile"
+    )
+    assert (
+        np.abs(test_rmsce_nonvectorized_quantile - test_rmsce_vectorized_quantile)
+        < 1e-6
+    )
+    assert np.abs(test_rmsce_vectorized_quantile - 0.30362567774902066) < 1e-6
+
+
+def test_root_mean_squared_calibration_error_on_test_set_torch(supply_test_set_torch):
+    """Test root mean squared calibration error on some dummy values."""
+    test_rmsce_nonvectorized_interval = root_mean_squared_calibration_error(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=False,
+        recal_model=None,
+        prop_type="interval"
+    )
+    test_rmsce_vectorized_interval = root_mean_squared_calibration_error(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=True,
+        recal_model=None,
+        prop_type="interval"
+    )
+    assert (
+        np.abs(test_rmsce_nonvectorized_interval - test_rmsce_vectorized_interval)
+        < 1e-6
+    )
+    assert np.abs(test_rmsce_vectorized_interval - 0.4165757476562379) < 1e-6
+
+    test_rmsce_nonvectorized_quantile = root_mean_squared_calibration_error(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=False,
+        recal_model=None,
+        prop_type="quantile"
+    )
+    test_rmsce_vectorized_quantile = root_mean_squared_calibration_error(
+        *supply_test_set_torch,
         num_bins=100,
         vectorized=True,
         recal_model=None,
@@ -117,6 +172,47 @@ def test_mean_absolute_calibration_error_on_test_set(supply_test_set):
     assert np.abs(test_mace_vectorized_quantile - 0.23757575757575758) < 1e-6
 
 
+def test_mean_absolute_calibration_error_on_test_set_torch(supply_test_set_torch):
+    """Test mean absolute calibration error on some dummy values."""
+    test_mace_nonvectorized_interval = mean_absolute_calibration_error(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=False,
+        recal_model=None,
+        prop_type="interval"
+    )
+    test_mace_vectorized_interval = mean_absolute_calibration_error(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=True,
+        recal_model=None,
+        prop_type="interval"
+    )
+    assert (
+        np.abs(test_mace_nonvectorized_interval - test_mace_vectorized_interval) < 1e-6
+    )
+    assert np.abs(test_mace_vectorized_interval - 0.3733333333333335) < 1e-6
+
+    test_mace_nonvectorized_quantile = mean_absolute_calibration_error(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=False,
+        recal_model=None,
+        prop_type="quantile"
+    )
+    test_mace_vectorized_quantile = mean_absolute_calibration_error(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=True,
+        recal_model=None,
+        prop_type="quantile"
+    )
+    assert (
+        np.abs(test_mace_nonvectorized_quantile - test_mace_vectorized_quantile) < 1e-6
+    )
+    assert np.abs(test_mace_vectorized_quantile - 0.23757575757575758) < 1e-6
+
+
 def test_adversarial_group_calibration_on_test_set(supply_test_set):
     """Test adversarial group calibration on test set for some dummy values."""
     test_out_interval = adversarial_group_calibration(
@@ -138,6 +234,43 @@ def test_adversarial_group_calibration_on_test_set(supply_test_set):
 
     test_out_quantile = adversarial_group_calibration(
         *supply_test_set,
+        cali_type="mean_abs",
+        prop_type="quantile",
+        num_bins=100,
+        num_group_bins=10,
+        draw_with_replacement=False,
+        num_trials=10,
+        num_group_draws=10,
+        verbose=False
+    )
+
+    assert np.max(np.abs(test_out_quantile.group_size - np.linspace(0, 1, 10))) < 1e-6
+    assert np.all(test_out_quantile.score_mean < 0.5)
+    assert np.abs(test_out_quantile.score_mean[-1] - 0.2375757575757576) < 1e-6
+    assert np.min(test_out_quantile.score_stderr) >= 0
+
+
+def test_adversarial_group_calibration_on_test_set_torch(supply_test_set_torch):
+    """Test adversarial group calibration on test set for some dummy values."""
+    test_out_interval = adversarial_group_calibration(
+        *supply_test_set_torch,
+        cali_type="mean_abs",
+        prop_type="interval",
+        num_bins=100,
+        num_group_bins=10,
+        draw_with_replacement=False,
+        num_trials=10,
+        num_group_draws=10,
+        verbose=False
+    )
+
+    assert np.max(np.abs(test_out_interval.group_size - np.linspace(0, 1, 10))) < 1e-6
+    assert np.all(test_out_interval.score_mean < 0.5)
+    assert np.abs(test_out_interval.score_mean[-1] - 0.3733333333333335) < 1e-6
+    assert np.min(test_out_interval.score_stderr) >= 0
+
+    test_out_quantile = adversarial_group_calibration(
+        *supply_test_set_torch,
         cali_type="mean_abs",
         prop_type="quantile",
         num_bins=100,
@@ -203,6 +336,55 @@ def test_miscalibration_area_on_test_set(supply_test_set):
     assert np.abs(test_miscal_area_vectorized_quantile - 0.23916245791245785) < 1e-6
 
 
+def test_miscalibration_area_on_test_set_torch(supply_test_set_torch):
+    """Test miscalibration area on some dummy values."""
+    test_miscal_area_nonvectorized_interval = miscalibration_area(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=False,
+        recal_model=None,
+        prop_type="interval"
+    )
+    test_miscal_area_vectorized_interval = miscalibration_area(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=True,
+        recal_model=None,
+        prop_type="interval"
+    )
+    assert (
+        np.abs(
+            test_miscal_area_nonvectorized_interval
+            - test_miscal_area_vectorized_interval
+        )
+        < 1e-6
+    )
+    assert np.abs(test_miscal_area_vectorized_interval - 0.37710437710437716) < 1e-6
+
+    test_miscal_area_nonvectorized_quantile = miscalibration_area(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=False,
+        recal_model=None,
+        prop_type="quantile"
+    )
+    test_miscal_area_vectorized_quantile = miscalibration_area(
+        *supply_test_set_torch,
+        num_bins=100,
+        vectorized=True,
+        recal_model=None,
+        prop_type="quantile"
+    )
+    assert (
+        np.abs(
+            test_miscal_area_nonvectorized_quantile
+            - test_miscal_area_vectorized_quantile
+        )
+        < 1e-6
+    )
+    assert np.abs(test_miscal_area_vectorized_quantile - 0.23916245791245785) < 1e-6
+
+
 def test_vectorization_for_proportion_list_on_test_set(supply_test_set):
     """Test vectorization in get_proportion_lists on the test set for some dummy values."""
     (
@@ -250,6 +432,53 @@ def test_vectorization_for_proportion_list_on_test_set(supply_test_set):
     )
 
 
+def test_vectorization_for_proportion_list_on_test_set_torch(supply_test_set_torch):
+    """Test vectorization in get_proportion_lists on the test set for some dummy values."""
+    (
+        test_exp_props_nonvec_interval,
+        test_obs_props_nonvec_interval,
+    ) = get_proportion_lists(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="interval"
+    )
+
+    (
+        test_exp_props_vec_interval,
+        test_obs_props_vec_interval,
+    ) = get_proportion_lists_vectorized(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="interval"
+    )
+    assert (
+        np.max(np.abs(test_exp_props_nonvec_interval - test_exp_props_vec_interval))
+        < 1e-6
+    )
+    assert (
+        np.max(np.abs(test_obs_props_nonvec_interval - test_obs_props_vec_interval))
+        < 1e-6
+    )
+
+    (
+        test_exp_props_nonvec_quantile,
+        test_obs_props_nonvec_quantile,
+    ) = get_proportion_lists(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="quantile"
+    )
+
+    (
+        test_exp_props_vec_quantile,
+        test_obs_props_vec_quantile,
+    ) = get_proportion_lists_vectorized(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="quantile"
+    )
+    assert (
+        np.max(np.abs(test_exp_props_nonvec_quantile - test_exp_props_vec_quantile))
+        < 1e-6
+    )
+    assert (
+        np.max(np.abs(test_obs_props_nonvec_quantile - test_obs_props_vec_quantile))
+        < 1e-6
+    )
+
+
 def test_get_proportion_lists_vectorized_on_test_set(supply_test_set):
     """Test get_proportion_lists_vectorized on the test set for some dummy values."""
     (
@@ -278,6 +507,50 @@ def test_get_proportion_lists_vectorized_on_test_set(supply_test_set):
         test_obs_props_quantile,
     ) = get_proportion_lists_vectorized(
         *supply_test_set, num_bins=100, recal_model=None, prop_type="quantile"
+    )
+    assert test_exp_props_quantile.shape == test_obs_props_quantile.shape
+    assert (
+        np.max(np.abs(np.unique(test_exp_props_quantile) - np.linspace(0, 1, 100)))
+        < 1e-6
+    )
+    assert (
+        np.max(
+            np.abs(
+                np.sort(np.unique(test_obs_props_quantile))
+                - np.array([0.0, 0.33333333, 0.66666667, 1.0])
+            )
+        )
+        < 1e-6
+    )
+
+def test_get_proportion_lists_vectorized_on_test_set_torch(supply_test_set_torch):
+    """Test get_proportion_lists_vectorized on the test set for some dummy values."""
+    (
+        test_exp_props_interval,
+        test_obs_props_interval,
+    ) = get_proportion_lists_vectorized(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="interval"
+    )
+    assert test_exp_props_interval.shape == test_obs_props_interval.shape
+    assert (
+        np.max(np.abs(np.unique(test_exp_props_interval) - np.linspace(0, 1, 100)))
+        < 1e-6
+    )
+    assert (
+        np.max(
+            np.abs(
+                np.sort(np.unique(test_obs_props_interval))
+                - np.array([0.0, 0.33333333, 0.66666667, 1.0])
+            )
+        )
+        < 1e-6
+    )
+
+    (
+        test_exp_props_quantile,
+        test_obs_props_quantile,
+    ) = get_proportion_lists_vectorized(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="quantile"
     )
     assert test_exp_props_quantile.shape == test_obs_props_quantile.shape
     assert (
@@ -334,6 +607,45 @@ def test_get_proportion_lists_on_test_set(supply_test_set):
     )
 
 
+def test_get_proportion_lists_on_test_set_torch(supply_test_set_torch):
+    """Test get_proportion_lists on the test set for some dummy values."""
+    test_exp_props_interval, test_obs_props_interval = get_proportion_lists(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="interval"
+    )
+    assert len(test_exp_props_interval) == len(test_obs_props_interval)
+    assert (
+        np.max(np.abs(np.unique(test_exp_props_interval) - np.linspace(0, 1, 100)))
+        < 1e-6
+    )
+    assert (
+        np.max(
+            np.abs(
+                np.sort(np.unique(test_obs_props_interval))
+                - np.array([0.0, 0.33333333, 0.66666667, 1.0])
+            )
+        )
+        < 1e-6
+    )
+
+    test_exp_props_quantile, test_obs_props_quantile = get_proportion_lists(
+        *supply_test_set_torch, num_bins=100, recal_model=None, prop_type="quantile"
+    )
+    assert len(test_exp_props_quantile) == len(test_obs_props_quantile)
+    assert (
+        np.max(np.abs(np.unique(test_exp_props_quantile) - np.linspace(0, 1, 100)))
+        < 1e-6
+    )
+    assert (
+        np.max(
+            np.abs(
+                np.sort(np.unique(test_obs_props_quantile))
+                - np.array([0.0, 0.33333333, 0.66666667, 1.0])
+            )
+        )
+        < 1e-6
+    )
+
+
 def test_get_proportion_in_interval_on_test_set(supply_test_set):
     """Test get_proportion_in_interval on the test set for some dummy values."""
     test_quantile_value_list = [
@@ -352,6 +664,24 @@ def test_get_proportion_in_interval_on_test_set(supply_test_set):
         )
 
 
+def test_get_proportion_in_interval_on_test_set_torch(supply_test_set_torch):
+    """Test get_proportion_in_interval on the test set for some dummy values."""
+    test_quantile_value_list = [
+        (0.0, 0.0),
+        (0.25, 0.0),
+        (0.5, 0.0),
+        (0.75, 0.3333333333333333),
+        (1.0, 1.0),
+    ]
+    for (test_q, test_val) in test_quantile_value_list:
+        assert (
+            np.abs(
+                get_proportion_in_interval(*supply_test_set_torch, quantile=test_q) - test_val
+            )
+            < 1e-6
+        )
+
+
 def test_get_proportion_under_quantile_on_test_set(supply_test_set):
     """Test get_proportion_in_interval on the test set for some dummy values."""
     test_quantile_value_list = [
@@ -365,6 +695,25 @@ def test_get_proportion_under_quantile_on_test_set(supply_test_set):
         assert (
             np.abs(
                 get_proportion_under_quantile(*supply_test_set, quantile=test_q)
+                - test_val
+            )
+            < 1e-6
+        )
+
+
+def test_get_proportion_under_quantile_on_test_set_torch(supply_test_set_torch):
+    """Test get_proportion_in_interval on the test set for some dummy values."""
+    test_quantile_value_list = [
+        (0.0, 0.0),
+        (0.25, 0.6666666666666666),
+        (0.5, 0.6666666666666666),
+        (0.75, 0.6666666666666666),
+        (1.0, 1.0),
+    ]
+    for (test_q, test_val) in test_quantile_value_list:
+        assert (
+            np.abs(
+                get_proportion_under_quantile(*supply_test_set_torch, quantile=test_q)
                 - test_val
             )
             < 1e-6
@@ -419,6 +768,54 @@ def test_get_prediction_interval_on_test_set(supply_test_set):
         assert np.max(np.abs(upper_bound - test_upper)) < 1e-6
 
 
+def test_get_prediction_interval_on_test_set_torch(supply_test_set_torch):
+    """Test get_prediction_interval on the test set for some dummy values."""
+    test_quantile_value_list = [
+        (
+            0.01,
+            np.array([1.00125335, 2.00626673, 3.01253347]),
+            np.array([0.99874665, 1.99373327, 2.98746653]),
+        ),
+        (
+            0.25,
+            np.array([1.03186394, 2.15931968, 3.31863936]),
+            np.array([0.96813606, 1.84068032, 2.68136064]),
+        ),
+        (
+            0.50,
+            np.array([1.06744898, 2.33724488, 3.67448975]),
+            np.array([0.93255102, 1.66275512, 2.32551025]),
+        ),
+        (
+            0.75,
+            np.array([1.11503494, 2.57517469, 4.15034938]),
+            np.array([0.88496506, 1.42482531, 1.84965062]),
+        ),
+        (
+            0.99,
+            np.array([1.25758293, 3.28791465, 5.5758293]),
+            np.array([0.74241707, 0.71208535, 0.4241707]),
+        ),
+    ]
+
+    y_pred, y_std, y_true = supply_test_set_torch
+
+    with pytest.raises(Exception):
+        bounds = get_prediction_interval(y_pred, y_std, quantile=0.0, recal_model=None)
+
+    with pytest.raises(Exception):
+        bounds = get_prediction_interval(y_pred, y_std, quantile=1.0, recal_model=None)
+
+    for (test_q, test_upper, test_lower) in test_quantile_value_list:
+        bounds = get_prediction_interval(
+            y_pred, y_std, quantile=test_q, recal_model=None
+        )
+        upper_bound = bounds.upper
+        lower_bound = bounds.lower
+        assert np.max(np.abs(upper_bound - test_upper)) < 1e-6
+        assert np.max(np.abs(upper_bound - test_upper)) < 1e-6
+
+
 def test_get_quantile_on_test_set(supply_test_set):
     """Test get_prediction_interval on the test set for some dummy values."""
     test_quantile_value_list = [
@@ -442,6 +839,42 @@ def test_get_quantile_on_test_set(supply_test_set):
     ]
 
     y_pred, y_std, y_true = supply_test_set
+
+    with pytest.raises(Exception):
+        bound = get_quantile(y_pred, y_std, quantile=0.0, recal_model=None)
+
+    with pytest.raises(Exception):
+        bound = get_quantile(y_pred, y_std, quantile=1.0, recal_model=None)
+
+    for (test_q, test_bound) in test_quantile_value_list:
+        bound = get_quantile(y_pred, y_std, quantile=test_q, recal_model=None)
+
+        assert np.max(np.abs(bound - test_bound)) < 1e-6
+
+
+def test_get_quantile_on_test_set_torch(supply_test_set_torch):
+    """Test get_prediction_interval on the test set for some dummy values."""
+    test_quantile_value_list = [
+        (0.01, np.array([0.76736521, 0.83682606, 0.67365213])),
+        (
+            0.25,
+            np.array([0.93255102, 1.66275512, 2.32551025]),
+        ),
+        (
+            0.50,
+            np.array([1.0, 2.0, 3.0]),
+        ),
+        (
+            0.75,
+            np.array([1.06744898, 2.33724488, 3.67448975]),
+        ),
+        (
+            0.99,
+            np.array([1.23263479, 3.16317394, 5.32634787]),
+        ),
+    ]
+
+    y_pred, y_std, y_true = supply_test_set_torch
 
     with pytest.raises(Exception):
         bound = get_quantile(y_pred, y_std, quantile=0.0, recal_model=None)

--- a/tests/test_metrics_scoring_rule.py
+++ b/tests/test_metrics_scoring_rule.py
@@ -3,6 +3,7 @@ Tests for scoring rule metrics.
 """
 import numpy as np
 import pytest
+import torch
 
 from uncertainty_toolbox.metrics_scoring_rule import (
     nll_gaussian,
@@ -17,6 +18,13 @@ def supply_test_set():
     y_pred = np.array([1, 2, 3])
     y_std = np.array([0.1, 0.5, 1])
     y_true = np.array([1.5, 3, 2])
+    return y_pred, y_std, y_true
+
+@pytest.fixture
+def supply_test_set_torch():
+    y_pred = torch.tensor([1., 2., 3.])
+    y_std = torch.tensor([0.1, 0.5, 1])
+    y_true = torch.tensor([1.5, 3, 2])
     return y_pred, y_std, y_true
 
 
@@ -73,6 +81,70 @@ def test_interval_score_on_one_pt():
     y_pred = np.array([0])
     y_true = np.array([0])
     y_std = np.array([1])
+    score = interval_score(
+        y_pred=y_pred,
+        y_std=y_std,
+        y_true=y_true,
+        start_p=0.682,
+        end_p=0.954,
+        resolution=2,
+    )
+    assert np.abs(score - 3) < 1e-2
+
+
+def test_nll_gaussian_on_test_set_torch(supply_test_set_torch):
+    """Test Gaussian NLL on the test set for some dummy values."""
+    assert np.abs(nll_gaussian(*supply_test_set_torch) - 4.920361108686675) < 1e-6
+
+
+def test_nll_gaussian_on_one_pt_torch():
+    """Sanity check by testing one point at mean of gaussian."""
+    y_pred = torch.tensor([0.])
+    y_true = torch.tensor([0.])
+    y_std = torch.tensor([1 / np.sqrt(2 * np.pi)])
+    assert np.abs(nll_gaussian(y_pred, y_std, y_true)) < 1e-6
+
+
+def test_crps_gaussian_on_test_set_torch(supply_test_set_torch):
+    """Test CRPS on the test set for some dummy values."""
+    assert np.abs(crps_gaussian(*supply_test_set_torch) - 0.59080610693) < 1e-6
+
+
+def test_check_score_on_test_set_torch(supply_test_set_torch):
+    """Test check score on the test set for some dummy values."""
+    assert np.abs(check_score(*supply_test_set_torch) - 0.29801437323836477) < 1e-6
+
+
+def test_check_score_on_one_pt_torch():
+    """Sanity check to show that check score is minimized (i.e. 0) if data
+    occurs at the exact requested quantile."""
+    y_pred = torch.tensor([0.])
+    y_true = torch.tensor([1.])
+    y_std = torch.tensor([1.])
+    score = check_score(
+        y_pred=y_pred,
+        y_std=y_std,
+        y_true=y_true,
+        start_q=0.5 + 0.341,
+        end_q=0.5 + 0.341,
+        resolution=1,
+    )
+    assert np.abs(score) < 1e-2
+
+
+def test_interval_score_on_test_set_torch(supply_test_set_torch):
+    """Test interval score on the test set for some dummy values."""
+    assert np.abs(interval_score(*supply_test_set_torch) - 3.20755700861995) < 1e-6
+
+
+def test_interval_score_on_one_pt_torch():
+    """Sanity check on interval score. For one point in the center of the
+    distribution and intervals one standard deviation and two standard
+    deviations away, should return ((1 std) * 2 + (2 std) * 2) / 2 = 3.
+    """
+    y_pred = torch.tensor([0])
+    y_true = torch.tensor([0])
+    y_std = torch.tensor([1])
     score = interval_score(
         y_pred=y_pred,
         y_std=y_std,

--- a/tests/test_metrics_scoring_rule.py
+++ b/tests/test_metrics_scoring_rule.py
@@ -142,9 +142,9 @@ def test_interval_score_on_one_pt_torch():
     distribution and intervals one standard deviation and two standard
     deviations away, should return ((1 std) * 2 + (2 std) * 2) / 2 = 3.
     """
-    y_pred = torch.tensor([0])
-    y_true = torch.tensor([0])
-    y_std = torch.tensor([1])
+    y_pred = torch.tensor([0.])
+    y_true = torch.tensor([0.])
+    y_std = torch.tensor([1.])
     score = interval_score(
         y_pred=y_pred,
         y_std=y_std,

--- a/tests/test_recalibration.py
+++ b/tests/test_recalibration.py
@@ -5,6 +5,7 @@ import random
 
 import numpy as np
 import pytest
+import torch
 
 
 from uncertainty_toolbox.recalibration import (
@@ -22,6 +23,7 @@ from uncertainty_toolbox.metrics_calibration import (
     get_prediction_interval,
     get_quantile,
 )
+from uncertainty_toolbox.utils import to_np_array
 
 
 @pytest.fixture
@@ -29,6 +31,13 @@ def supply_test_set():
     y_pred = np.arange(100) / 100.0
     y_std = np.arange(1, 101) / 20.0
     y_true = np.arange(100) / 100.0 + 0.5
+    return y_pred, y_std, y_true
+
+@pytest.fixture
+def supply_test_set_torch():
+    y_pred = torch.arange(100.) / 100.0
+    y_std = torch.arange(1, 101) / 20.0
+    y_true = torch.arange(100) / 100.0 + 0.5
     return y_pred, y_std, y_true
 
 
@@ -289,5 +298,266 @@ def test_get_interval_recalibrator(supply_test_set):
         interval_recal = interval_recalibrator(y_pred, y_std, q)
         prop_in_interval_recal = (
             (interval_recal.lower <= y_true) * (y_true <= interval_recal.upper)
+        ).mean()
+        assert np.max(np.abs(test_prop_in_interval - prop_in_interval_recal)) < 1e-3
+
+
+def test_recal_model_mace_criterion_on_test_set_torch(supply_test_set_torch):
+    """
+    Test recalibration on mean absolute calibration error on the test set
+    for some dummy values.
+    """
+    test_mace = mean_absolute_calibration_error(
+        *supply_test_set_torch, num_bins=100, vectorized=True, recal_model=None
+    )
+    test_exp_props, test_obs_props = get_proportion_lists_vectorized(
+        *supply_test_set_torch, num_bins=100, recal_model=None
+    )
+    recal_model = iso_recal(test_exp_props, test_obs_props)
+    recal_test_mace = mean_absolute_calibration_error(
+        *supply_test_set_torch, num_bins=100, vectorized=True, recal_model=recal_model
+    )
+    recal_exp_props = recal_model.predict(test_obs_props)
+    assert np.abs(test_mace - 0.24206060606060598) < 1e-3
+    assert np.abs(recal_test_mace - 0.003035353535353514) < 1e-3
+    for idx in range(1, recal_exp_props.shape[0]):
+        assert recal_exp_props[idx - 1] <= recal_exp_props[idx]
+
+
+def test_recal_model_rmce_criterion_on_test_set_torch(supply_test_set_torch):
+    """
+    Test recalibration on root mean squared calibration error on the test set
+    for some dummy values.
+    """
+    test_rmsce = root_mean_squared_calibration_error(
+        *supply_test_set_torch, num_bins=100, vectorized=True, recal_model=None
+    )
+    test_exp_props, test_obs_props = get_proportion_lists_vectorized(
+        *supply_test_set_torch, num_bins=100, recal_model=None
+    )
+    recal_model = iso_recal(test_exp_props, test_obs_props)
+    recal_test_rmsce = root_mean_squared_calibration_error(
+        *supply_test_set_torch, num_bins=100, vectorized=True, recal_model=recal_model
+    )
+    recal_exp_props = recal_model.predict(test_obs_props)
+
+    assert np.abs(test_rmsce - 0.28741418862839013) < 1e-3
+    assert np.abs(recal_test_rmsce - 0.003981861230030349) < 1e-3
+    for idx in range(1, recal_exp_props.shape[0]):
+        assert recal_exp_props[idx - 1] <= recal_exp_props[idx]
+
+
+def test_recal_model_miscal_area_criterion_on_test_set(supply_test_set_torch):
+    """
+    Test recalibration on miscalibration area on the test set
+    for some dummy values.
+    """
+    test_miscal_area = miscalibration_area(
+        *supply_test_set_torch, num_bins=100, vectorized=True, recal_model=None
+    )
+    test_exp_props, test_obs_props = get_proportion_lists_vectorized(
+        *supply_test_set_torch, num_bins=100, recal_model=None
+    )
+    recal_model = iso_recal(test_exp_props, test_obs_props)
+    recal_test_miscal_area = miscalibration_area(
+        *supply_test_set_torch, num_bins=100, vectorized=True, recal_model=recal_model
+    )
+    recal_exp_props = recal_model.predict(test_obs_props)
+
+    assert np.abs(test_miscal_area - 0.24426139657444004) < 1e-3
+    assert np.abs(recal_test_miscal_area - 0.0029569160997732244) < 1e-3
+    for idx in range(1, recal_exp_props.shape[0]):
+        assert recal_exp_props[idx - 1] <= recal_exp_props[idx]
+
+
+def test_optimize_recalibration_ratio_mace_criterion_torch(supply_test_set_torch):
+    """
+    Test standard deviation recalibration on mean absolute calibration error
+    on the test set for some dummy values.
+    """
+    random.seed(0)
+    np.random.seed(seed=0)
+
+    y_pred, y_std, y_true = supply_test_set_torch
+    ma_cal_ratio = optimize_recalibration_ratio(
+        y_pred, y_std, y_true, criterion="ma_cal"
+    )
+    recal_ma_cal = mean_absolute_calibration_error(y_pred, ma_cal_ratio * y_std, y_true)
+    recal_rms_cal = root_mean_squared_calibration_error(
+        y_pred, ma_cal_ratio * y_std, y_true
+    )
+    recal_miscal = miscalibration_area(y_pred, ma_cal_ratio * y_std, y_true)
+
+    assert np.abs(ma_cal_ratio - 0.33215708813773176) < 1e-3
+    assert np.abs(recal_ma_cal - 0.06821616161616162) < 1e-3
+    assert np.abs(recal_rms_cal - 0.08800130087804929) < 1e-3
+    assert np.abs(recal_miscal - 0.06886262626262629) < 1e-3
+
+
+def test_optimize_recalibration_ratio_rmce_criterion_torch(supply_test_set_torch):
+    """
+    Test standard deviation recalibration on root mean squared calibration error
+    on the test set for some dummy values.
+    """
+    random.seed(0)
+    np.random.seed(seed=0)
+
+    y_pred, y_std, y_true = supply_test_set_torch
+    rms_cal_ratio = optimize_recalibration_ratio(
+        y_pred, y_std, y_true, criterion="rms_cal"
+    )
+    recal_ma_cal = mean_absolute_calibration_error(
+        y_pred, rms_cal_ratio * y_std, y_true
+    )
+    recal_rms_cal = root_mean_squared_calibration_error(
+        y_pred, rms_cal_ratio * y_std, y_true
+    )
+    recal_miscal = miscalibration_area(y_pred, rms_cal_ratio * y_std, y_true)
+
+    assert np.abs(rms_cal_ratio - 0.34900989073212507) < 1e-3
+    assert np.abs(recal_ma_cal - 0.06945555555555555) < 1e-3
+    assert np.abs(recal_rms_cal - 0.08570902541177935) < 1e-3
+    assert np.abs(recal_miscal - 0.07011706864564003) < 1e-3
+
+
+def test_optimize_recalibration_ratio_miscal_area_criterion_torch(supply_test_set_torch):
+    """
+    Test standard deviation recalibration on miscalibration area
+    on the test set for some dummy values.
+    """
+    random.seed(0)
+    np.random.seed(seed=0)
+
+    y_pred, y_std, y_true = supply_test_set_torch
+    miscal_ratio = optimize_recalibration_ratio(
+        y_pred, y_std, y_true, criterion="miscal"
+    )
+    recal_ma_cal = mean_absolute_calibration_error(y_pred, miscal_ratio * y_std, y_true)
+    recal_rms_cal = root_mean_squared_calibration_error(
+        y_pred, miscal_ratio * y_std, y_true
+    )
+    recal_miscal = miscalibration_area(y_pred, miscal_ratio * y_std, y_true)
+
+    assert np.abs(miscal_ratio - 0.3321912522557988) < 1e-3
+    assert np.abs(recal_ma_cal - 0.06821616161616162) < 1e-3
+    assert np.abs(recal_rms_cal - 0.08800130087804929) < 1e-3
+    assert np.abs(recal_miscal - 0.06886262626262629) < 1e-3
+
+
+def test_get_prediction_interval_recalibrated_torch(supply_test_set_torch):
+    """
+    Test standard deviation recalibration on miscalibration area
+    on the test set for some dummy values.
+    """
+    random.seed(0)
+    np.random.seed(seed=0)
+
+    y_pred, y_std, y_true = supply_test_set_torch
+    test_exp_props, test_obs_props = get_proportion_lists_vectorized(
+        y_pred, y_std, y_true, num_bins=100, recal_model=None
+    )
+    recal_model = iso_recal(test_exp_props, test_obs_props)
+
+    test_quantile_prop_list = [
+        (0.01, 0.0, 0.0),
+        (0.25, 0.69, 0.25),
+        (0.5, 0.86, 0.5),
+        (0.75, 0.92, 0.75),
+        (0.99, 0.97, 0.97),
+    ]
+
+    for (q, test_orig_prop, test_recal_prop) in test_quantile_prop_list:
+        orig_bounds = get_prediction_interval(y_pred, y_std, q, None)
+        recal_bounds = get_prediction_interval(y_pred, y_std, q, recal_model)
+
+        orig_prop = np.mean(
+            (orig_bounds.lower <= to_np_array(y_true)) * (to_np_array(y_true) <= orig_bounds.upper)
+        )
+        recal_prop = np.mean(
+            (recal_bounds.lower <= to_np_array(y_true)) * (to_np_array(y_true) <= recal_bounds.upper)
+        )
+
+        assert np.max(np.abs(test_orig_prop - orig_prop)) < 1e-3
+        assert np.max(np.abs(test_recal_prop - recal_prop)) < 1e-3
+
+
+def test_get_std_recalibrator_torch(supply_test_set_torch):
+    """
+    Test get_std_recalibration on the test set for some dummy values.
+    """
+    random.seed(0)
+    np.random.seed(seed=0)
+
+    y_pred, y_std, y_true = supply_test_set_torch
+
+    test_quantile_prop_list = [
+        (0.01, 0.00, 0.00),
+        (0.25, 0.06, 0.00),
+        (0.50, 0.56, 0.00),
+        (0.75, 0.74, 0.56),
+        (0.99, 0.89, 0.88),
+    ]
+
+    std_recalibrator = get_std_recalibrator(y_pred, y_std, y_true)
+
+    for (q, test_prop_in_pi, test_prop_under_q) in test_quantile_prop_list:
+        y_std_recal = std_recalibrator(y_std)
+        pi = get_prediction_interval(y_pred, y_std_recal, q)
+        prop_in_pi = ((pi.lower <= to_np_array(y_true)) * (to_np_array(y_true) <= pi.upper)).mean()
+        quantile_bound = get_quantile(y_pred, y_std_recal, q)
+        prop_under_q = (quantile_bound >= to_np_array(y_true)).mean()
+        assert np.max(np.abs(test_prop_in_pi - prop_in_pi)) < 1e-3
+        assert np.max(np.abs(test_prop_under_q - prop_under_q)) < 1e-3
+
+
+def test_get_quantile_recalibrator_torch(supply_test_set_torch):
+    """
+    Test get_std_recalibration on the test set for some dummy values.
+    """
+    random.seed(0)
+    np.random.seed(seed=0)
+
+    y_pred, y_std, y_true = supply_test_set_torch
+
+    test_quantile_prop_list = [
+        (0.01, 0.00),
+        (0.25, 0.00),
+        (0.50, 0.00),
+        (0.75, 0.00),
+        (0.99, 0.83),
+    ]
+
+    quantile_recalibrator = get_quantile_recalibrator(y_pred, y_std, y_true)
+
+    for (q, test_prop_under_q) in test_quantile_prop_list:
+        quantile_bound_recal = quantile_recalibrator(y_pred, y_std, q)
+        assert all(np.isfinite(quantile_bound_recal))
+        prop_under_q_recal = (quantile_bound_recal >= to_np_array(y_true)).mean()
+        assert np.max(np.abs(test_prop_under_q - prop_under_q_recal)) < 1e-3
+
+
+def test_get_interval_recalibrator_torch(supply_test_set_torch):
+    """
+    Test get_std_recalibration on the test set for some dummy values.
+    """
+    random.seed(0)
+    np.random.seed(seed=0)
+
+    y_pred, y_std, y_true = supply_test_set_torch
+
+    test_quantile_prop_list = [
+        (0.01, 0.00),
+        (0.25, 0.25),
+        (0.50, 0.50),
+        (0.75, 0.75),
+        (0.99, 0.97),
+    ]
+
+    interval_recalibrator = get_interval_recalibrator(y_pred, y_std, y_true)
+
+    for (q, test_prop_in_interval) in test_quantile_prop_list:
+        interval_recal = interval_recalibrator(y_pred, y_std, q)
+        prop_in_interval_recal = (
+            (interval_recal.lower <= to_np_array(y_true)) * (to_np_array(y_true) <= interval_recal.upper)
         ).mean()
         assert np.max(np.abs(test_prop_in_interval - prop_in_interval_recal)) < 1e-3

--- a/uncertainty_toolbox/metrics_scoring_rule.py
+++ b/uncertainty_toolbox/metrics_scoring_rule.py
@@ -5,13 +5,16 @@ uncertainty quantification.
 
 import numpy as np
 from scipy import stats
-from uncertainty_toolbox.utils import assert_is_flat_same_shape
+import torch
+from torch.distributions import Normal
+from typing import Union
+from uncertainty_toolbox.utils import assert_is_flat_same_shape, sum_fn, mean_fn
 
 
 def nll_gaussian(
-    y_pred: np.ndarray,
-    y_std: np.ndarray,
-    y_true: np.ndarray,
+    y_pred: Union[np.ndarray, torch.Tensor],
+    y_std: Union[np.ndarray, torch.Tensor],
+    y_true: Union[np.ndarray, torch.Tensor],
     scaled: bool = True,
 ) -> float:
     """Negative log likelihood for a gaussian.
@@ -36,8 +39,13 @@ def nll_gaussian(
     residuals = y_pred - y_true
 
     # Compute nll
-    nll_list = stats.norm.logpdf(residuals, scale=y_std)
-    nll = -1 * np.sum(nll_list)
+    if isinstance(y_pred, torch.Tensor):
+        dist = Normal(loc=torch.tensor(0., dtype=y_pred.dtype, device=y_pred.device),
+                      scale=y_std)
+        nll_list = dist.log_prob(residuals)
+    else:
+        nll_list = stats.norm.logpdf(residuals, scale=y_std)
+    nll = -1 * sum_fn(nll_list)
 
     # Potentially scale so that sum becomes mean
     if scaled:
@@ -47,9 +55,9 @@ def nll_gaussian(
 
 
 def crps_gaussian(
-    y_pred: np.ndarray,
-    y_std: np.ndarray,
-    y_true: np.ndarray,
+    y_pred: Union[np.ndarray, torch.Tensor],
+    y_std: Union[np.ndarray, torch.Tensor],
+    y_true: Union[np.ndarray, torch.Tensor],
     scaled: bool = True,
 ) -> float:
     """The negatively oriented continuous ranked probability score for Gaussians.
@@ -76,11 +84,19 @@ def crps_gaussian(
     # Compute crps
     y_standardized = (y_true - y_pred) / y_std
     term_1 = 1 / np.sqrt(np.pi)
-    term_2 = 2 * stats.norm.pdf(y_standardized, loc=0, scale=1)
-    term_3 = y_standardized * (2 * stats.norm.cdf(y_standardized, loc=0, scale=1) - 1)
+    if isinstance(y_pred, torch.Tensor):
+        device = y_pred.device
+        dtype = y_pred.dtype
+        dist = Normal(loc=torch.tensor([0.], dtype=dtype, device=device),
+                      scale=torch.tensor([1.], dtype=dtype, device=device))
+        term_2 = 2 * dist.log_prob(y_standardized).exp()
+        term_3 = y_standardized * (2 * dist.cdf(y_standardized) - 1)
+    else:
+        term_2 = 2 * stats.norm.pdf(y_standardized, loc=0, scale=1) 
+        term_3 = y_standardized * (2 * stats.norm.cdf(y_standardized, loc=0, scale=1) - 1)
 
     crps_list = -1 * y_std * (term_1 - term_2 - term_3)
-    crps = np.sum(crps_list)
+    crps = sum_fn(crps_list)
 
     # Potentially scale so that sum becomes mean
     if scaled:
@@ -90,9 +106,9 @@ def crps_gaussian(
 
 
 def check_score(
-    y_pred: np.ndarray,
-    y_std: np.ndarray,
-    y_true: np.ndarray,
+    y_pred: Union[np.ndarray, torch.Tensor],
+    y_std: Union[np.ndarray, torch.Tensor],
+    y_true: Union[np.ndarray, torch.Tensor],
     scaled: bool = True,
     start_q: float = 0.01,
     end_q: float = 0.99,
@@ -125,16 +141,30 @@ def check_score(
     # Check that input arrays are flat
     assert_is_flat_same_shape(y_pred, y_std, y_true)
 
-    test_qs = np.linspace(start_q, end_q, resolution)
+    if isinstance(y_pred, torch.Tensor):
+        device = y_pred.device
+        dtype = y_pred.dtype
+        test_qs = torch.linspace(start_q, end_q, resolution, dtype=dtype, device=device)
+    else:
+        test_qs = np.linspace(start_q, end_q, resolution)
 
-    check_list = []
-    for q in test_qs:
-        q_level = stats.norm.ppf(q, loc=y_pred, scale=y_std)  # pred quantile
+    if isinstance(y_pred, torch.Tensor):
+        # Tensor operation on the batch dimension of test_qs:
+        dist = Normal(loc=y_pred, scale=y_std)
+        q_level = dist.icdf(test_qs[...,None])
         diff = q_level - y_true
-        mask = (diff >= 0).astype(float) - q
-        score_per_q = np.mean(mask * diff)
-        check_list.append(score_per_q)
-    check_score = np.sum(check_list)
+        mask = (diff >= 0).float() - test_qs[...,None]
+        score_per_q = mean_fn(mask * diff, 1)
+        check_list = score_per_q
+    else:
+        check_list = []
+        for q in test_qs:
+            q_level = stats.norm.ppf(q, loc=y_pred, scale=y_std)  # pred quantile
+            diff = q_level - y_true
+            mask = (diff >= 0).astype(float) - q
+            score_per_q = np.mean(mask * diff)
+            check_list.append(score_per_q)
+    check_score = sum_fn(check_list)
 
     if scaled:
         check_score = check_score / len(check_list)
@@ -143,9 +173,9 @@ def check_score(
 
 
 def interval_score(
-    y_pred: np.ndarray,
-    y_std: np.ndarray,
-    y_true: np.ndarray,
+    y_pred: Union[np.ndarray, torch.Tensor],
+    y_std: Union[np.ndarray, torch.Tensor],
+    y_true: Union[np.ndarray, torch.Tensor],
     scaled: bool = True,
     start_p: float = 0.01,
     end_p: float = 0.99,
@@ -179,25 +209,45 @@ def interval_score(
     # Check that input arrays are flat
     assert_is_flat_same_shape(y_pred, y_std, y_true)
 
-    test_ps = np.linspace(start_p, end_p, resolution)
+    if isinstance(y_pred, torch.Tensor):
+        device = y_pred.device
+        dtype = y_pred.dtype
+        test_ps = torch.linspace(start_p, end_p, resolution, dtype=dtype, device=device)
+    else:
+        test_ps = np.linspace(start_p, end_p, resolution)
 
-    int_list = []
-    for p in test_ps:
-        low_p, high_p = 0.5 - (p / 2.0), 0.5 + (p / 2.0)  # p% PI
-        pred_l = stats.norm.ppf(low_p, loc=y_pred, scale=y_std)
-        pred_u = stats.norm.ppf(high_p, loc=y_pred, scale=y_std)
-
-        below_l = ((pred_l - y_true) > 0).astype(float)
-        above_u = ((y_true - pred_u) > 0).astype(float)
-
-        score_per_p = (
-            (pred_u - pred_l)
-            + (2.0 / (1 - p)) * (pred_l - y_true) * below_l
-            + (2.0 / (1 - p)) * (y_true - pred_u) * above_u
+    if isinstance(y_pred, torch.Tensor):
+        low_ps, high_ps = 0.5 - (test_ps / 2.0), 0.5 + (test_ps / 2.0)  # p% PI
+        dist = Normal(loc=y_pred, scale=y_std)
+        pred_ls = dist.icdf(low_ps[...,None])
+        pred_us = dist.icdf(high_ps[...,None])
+        below_ls = ((pred_ls - y_true) > 0).float()
+        above_us = ((y_true - pred_us) > 0).float()
+        score_per_ps = (
+            (pred_us - pred_ls)
+            + (2.0 / (1 - test_ps[...,None])) * (pred_ls - y_true) * below_ls
+            + (2.0 / (1 - test_ps[...,None])) * (y_true - pred_us) * above_us
         )
-        mean_score_per_p = np.mean(score_per_p)
-        int_list.append(mean_score_per_p)
-    int_score = np.sum(int_list)
+        mean_score_per_ps = mean_fn(score_per_ps, 1)
+        int_list = mean_score_per_ps
+    else:
+        int_list = []
+        for p in test_ps:
+            low_p, high_p = 0.5 - (p / 2.0), 0.5 + (p / 2.0)  # p% PI
+            pred_l = stats.norm.ppf(low_p, loc=y_pred, scale=y_std)
+            pred_u = stats.norm.ppf(high_p, loc=y_pred, scale=y_std)
+
+            below_l = ((pred_l - y_true) > 0).astype(float)
+            above_u = ((y_true - pred_u) > 0).astype(float)
+
+            score_per_p = (
+                (pred_u - pred_l)
+                + (2.0 / (1 - p)) * (pred_l - y_true) * below_l
+                + (2.0 / (1 - p)) * (y_true - pred_u) * above_u
+            )
+            mean_score_per_p = np.mean(score_per_p)
+            int_list.append(mean_score_per_p)
+    int_score = sum_fn(int_list)
 
     if scaled:
         int_score = int_score / len(int_list)


### PR DESCRIPTION
Add support to PyTorch tensors and GPU acceleration.

1. Add support to PyTorch tensors and GPU acceleration.
2. Add tests for all PyTorch tensor inputs. 

Authored-by: Tailin Wu <tailin@cs.stanford.edu>